### PR TITLE
Redirect git config checks to /dev/null

### DIFF
--- a/git-hooks/commit-msg-hooks/message-format.sh
+++ b/git-hooks/commit-msg-hooks/message-format.sh
@@ -2,7 +2,7 @@
 # Default to check that commit message has more than three words.
 set -e
 
-if ! git config --bool hooks.message-format.disabled ; then
+if ! git config --bool hooks.message-format.disabled > /dev/null ; then
     regex=$(git config hooks.message-format.regex || echo '(\w+\s+){4}')
     message=$(git config hooks.message-format.message || echo "Commit message does not adhere to '$regex'")
     perl -E "exit 1 if <> !~ /$regex/m" "$1" > /dev/null || (echo "$message"; exit 1)

--- a/git-hooks/pre-commit-hooks/exclude-strings.sh
+++ b/git-hooks/pre-commit-hooks/exclude-strings.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Run the hook if it has not been disabled by custom git configuration
-if ! git config --bool hooks.excluded-strings.disabled ; then
+if ! git config --bool hooks.excluded-strings.disabled > /dev/null ; then
     # Get the file name or a UUID (i.e. a file name that can't possibly exist by accident)
     file=$(git config hooks.excluded-strings.file || echo '0bd306a6-654b-42bd-996c-fded43fc14ff')
     # Copy the line seperate list of exclusions into a variable or default to 'TODO'

--- a/git-hooks/pre-commit-hooks/file-size.sh
+++ b/git-hooks/pre-commit-hooks/file-size.sh
@@ -21,7 +21,7 @@ EOF
 exec 1>&2
 
 # If you want to allow large files to be committed set this variable to true.
-if ! git config --bool hooks.file-size.disabled ; then
+if ! git config --bool hooks.file-size.disabled > /dev/null ; then
     toplevel=$(git rev-parse --show-toplevel)
     maxsize=$(git config --int hooks.file-size.bytes || echo 1000000)
     git diff --name-only --diff-filter=ACM --cached | while read -r x; do too_big "$x"; done

--- a/git-hooks/pre-commit-hooks/verify-author.sh
+++ b/git-hooks/pre-commit-hooks/verify-author.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Run the hook if it has not been disabled by custom git configuration.
-if ! git config --bool hooks.verify-author.disabled ; then
+if ! git config --bool hooks.verify-author.disabled > /dev/null ; then
     # Get the name and email of the author from the git configuration.
     name=$(git config user.name)
     email=$(git config user.email)


### PR DESCRIPTION
If any of the "disabled" configurations are set, it prints "true" when the hook runs. Redirect stdout to /dev/null to prevent this.